### PR TITLE
Support workflows defined under `export` property

### DIFF
--- a/bento_lib/package.cfg
+++ b/bento_lib/package.cfg
@@ -1,5 +1,5 @@
 [package]
 name = bento_lib
-version = 3.1.0
+version = 3.1.1
 authors = David Lougheed
 author_emails = david.lougheed@mail.mcgill.ca

--- a/bento_lib/workflows.py
+++ b/bento_lib/workflows.py
@@ -175,12 +175,19 @@ def secure_filename(fn: str) -> str:
 
 
 def workflow_exists(workflow_id: str, wfs: Dict):
-    return workflow_id in wfs["ingestion"] or workflow_id in wfs["analysis"]
+    for key in wfs:
+        if workflow_id in wfs[key]:
+            return True
+
+    return False
 
 
 def get_workflow(workflow_id: str, wfs: Dict):
-    return (wfs["ingestion"][workflow_id] if workflow_id in wfs["ingestion"]
-            else wfs["analysis"][workflow_id])
+    for key in wfs:
+        if workflow_id in wfs[key]:
+            return wfs[key][workflow_id]
+
+    raise KeyError(f'Workflow ID {workflow_id} not found.')
 
 
 def get_workflow_resource(workflow_id: str, wfs: Dict):

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -15,6 +15,11 @@ TEST_WORKFLOWS = {
         "test_analysis": {
             "file": "../../../test analysis.wdl"
         }
+    },
+    "export": {
+        "test_export": {
+            "file": "test_export.wdl"
+        }
     }
 }
 
@@ -266,14 +271,17 @@ def test_secure_filename():
 def test_workflow_exists():
     assert workflows.workflow_exists("test", TEST_WORKFLOWS)
     assert workflows.workflow_exists("test_analysis", TEST_WORKFLOWS)
+    assert workflows.workflow_exists("test_export", TEST_WORKFLOWS)
     assert not workflows.workflow_exists("does_not_exist", TEST_WORKFLOWS)
 
 
 def test_get_workflow():
     assert workflows.get_workflow("test", TEST_WORKFLOWS) == TEST_WORKFLOWS["ingestion"]["test"]
     assert workflows.get_workflow("test_analysis", TEST_WORKFLOWS) == TEST_WORKFLOWS["analysis"]["test_analysis"]
+    assert workflows.get_workflow("test_export", TEST_WORKFLOWS) == TEST_WORKFLOWS["export"]["test_export"]
 
 
 def test_get_workflow_resource():
     assert workflows.get_workflow_resource("test", TEST_WORKFLOWS) == "test.wdl"
     assert workflows.get_workflow_resource("test_analysis", TEST_WORKFLOWS) == "test_analysis.wdl"
+    assert workflows.get_workflow_resource("test_export", TEST_WORKFLOWS) == "test_export.wdl"

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -279,9 +279,13 @@ def test_get_workflow():
     assert workflows.get_workflow("test", TEST_WORKFLOWS) == TEST_WORKFLOWS["ingestion"]["test"]
     assert workflows.get_workflow("test_analysis", TEST_WORKFLOWS) == TEST_WORKFLOWS["analysis"]["test_analysis"]
     assert workflows.get_workflow("test_export", TEST_WORKFLOWS) == TEST_WORKFLOWS["export"]["test_export"]
+    with pytest.raises(KeyError):
+        workflows.get_workflow("does_not_exist", TEST_WORKFLOWS)
 
 
 def test_get_workflow_resource():
     assert workflows.get_workflow_resource("test", TEST_WORKFLOWS) == "test.wdl"
     assert workflows.get_workflow_resource("test_analysis", TEST_WORKFLOWS) == "test_analysis.wdl"
     assert workflows.get_workflow_resource("test_export", TEST_WORKFLOWS) == "test_export.wdl"
+    with pytest.raises(KeyError):
+        workflows.get_workflow_resource("does_not_exist", TEST_WORKFLOWS)


### PR DESCRIPTION
To implement cBioPortal integration in Bento, a specific workflow for exporting data needs to be defined.
At the moment Workflows are only classified under "ingestion" or "analysis" keys, neither of which are appropriate for "namespacing" and export.
bento_lib has these keys hardcoded which breaks any addition of an "export" key.
This PR loosens the checks on the workflows keys in order to detect a workflow as long as it is defined under any key in the workflows dictionary.

## Testing
It can be tested using 
```terminal
python3 -m pytest tests/test_workflows.py   
```
I have not been able to run the whole test suite as it makes tests against a specific installation of DRS and Reddis which I don't know how to reproduce.

I've also tested the package in the context of Katsu by packaging the library, copying the result in Katsu container, from that container performing a pip based installation by pointing to that specific tar.
```terminal
python3 setup.py sdist bdist_wheel      
docker cp dist/bento_lib-3.1.1.tar.gz bentov2-katsu:/tmp/.

### From Katsu container
pip install /tmp/bento_lib-3.1.1.tar.gz 
python manage.py test
```
