### PR TITLE
feat: project/dataset view permissions

### DIFF
--- a/bento_lib/auth/permissions.py
+++ b/bento_lib/auth/permissions.py
@@ -147,6 +147,10 @@ P_QUERY_PROJECT_LEVEL_COUNTS = Permission(
 )
 P_QUERY_DATASET_LEVEL_COUNTS = Permission(QUERY_VERB, DATASET_LEVEL_COUNTS, gives=(P_QUERY_DATASET_LEVEL_BOOLEAN,))
 
+# Data catalog: permissions to view project/dataset metadata
+P_VIEW_DATASETS = Permission(VIEW_VERB, DATASET, min_level_required=LEVEL_INSTANCE)
+P_VIEW_PROJECTS = Permission(VIEW_VERB, PROJECT, min_level_required=LEVEL_INSTANCE)
+
 # Data-level: interacting with data inside of data services... and triggering workflows
 
 P_QUERY_DATA = Permission(


### PR DESCRIPTION
Intended for data catalog, for situations where listing the metadata of projects/datasets must be authorized.

Accompanying Katsu/Bento PRs will:
- Add configuration flags for catalog authz in Bento/Katsu
   - `BENTO_KATSU_PUBLIC_PROJECTS_AUTHZ`
   - `BENTO_KATSU_PUBLIC_DATASETS_AUTHZ`
- Make Katsu's `/projects` and `/datasets` endpoints authz protected based on the feature flags