### PR TITLE
fix: apply min_length constraint to string branch of spatial_coverage union

### DIFF
--- a/bento_lib/provenance/dataset.py
+++ b/bento_lib/provenance/dataset.py
@@ -346,7 +346,7 @@ class DatasetModelBase(TranslatableModel):
     stakeholders: list[PersonOrOrganization] | None = Field(default=None, min_length=1)
     funding_sources: list[FundingSource | Link] | Annotated[str, Field(min_length=1)] | None = None
 
-    spatial_coverage: str | SpatialCoverageFeature | None = Field(default=None, min_length=1)
+    spatial_coverage: Annotated[str, Field(min_length=1)] | SpatialCoverageFeature | None = None
     version: str | None = Field(default=None, min_length=1)
     privacy: str | None = Field(default=None, min_length=1)
     license: License | None = None


### PR DESCRIPTION
Use `Annotated[str, Field(min_length=1)]` so the constraint applies to the string type only, not the whole union.