### PR TITLE
feat(provenance): add duo_codes field to DatasetModelBase

### DIFF
--- a/bento_lib/provenance/dataset.py
+++ b/bento_lib/provenance/dataset.py
@@ -397,6 +397,12 @@ class DatasetModelBase(TranslatableModel):
     study_status: Literal["ONGOING", "COMPLETED"] | None = None
     study_context: Literal["CLINICAL", "RESEARCH"] | None = None
 
+    duo_codes: list[OntologyClass] | None = Field(
+        default=None,
+        min_length=1,
+        description="Data Use Ontology (DUO) codes describing the conditions under which this dataset can be accessed",
+    )
+
     # Derived from the PCGL study model
     domain: list[str] | None = Field(
         default=None, min_length=1, description="List of specific scientific or clinical domains addressed by the study"
@@ -440,6 +446,11 @@ class DatasetModelBase(TranslatableModel):
             )
             if missing:
                 raise ValueError(f"taxa contains OntologyClass CURIEs with no matching resource: {missing}")
+
+        if self.duo_codes:
+            missing = sorted({code.id.split(":")[0] for code in self.duo_codes} - resource_prefixes)
+            if missing:
+                raise ValueError(f"duo_codes contain OntologyClass CURIEs with no matching resource: {missing}")
 
         if self.stakeholders:
             missing_roles = [s.name for s in self.stakeholders if isinstance(s, Person) and not s.roles]

--- a/tests/provenance/test_provenance_dataset.py
+++ b/tests/provenance/test_provenance_dataset.py
@@ -252,3 +252,35 @@ def test_funding_source_all_null_invalid():
     """FundingSource rejects a completely empty initialization."""
     with pytest.raises(ValidationError):
         FundingSource(funder=None, grant_numbers=None)
+
+
+def test_dataset_model_duo_codes_resource_validation(dataset_minimal):
+    """DUO code OntologyClass entries must have a matching resource by namespace_prefix."""
+    ds_dict = dataset_minimal.model_dump()
+    del ds_dict["identifier"]
+
+    DUO_RESOURCE = {
+        "id": "duo",
+        "version": "2021-02-23",
+        "namespace_prefix": "DUO",
+        "iri_prefix": "http://purl.obolibrary.org/obo/DUO_",
+        "url": "http://purl.obolibrary.org/obo/duo.owl",
+        "name": "Data Use Ontology",
+    }
+    ds_dict["duo_codes"] = [{"id": "DUO:0000007", "label": "disease specific research"}]
+
+    # DUO resource missing — should fail
+    ds_dict["resources"] = None
+    with pytest.raises(Exception, match="no matching resource"):
+        DatasetModelBase.model_validate(ds_dict)
+
+    # DUO resource present — should pass
+    ds_dict["resources"] = [DUO_RESOURCE]
+    ds = DatasetModelBase.model_validate(ds_dict)
+    assert ds.duo_codes is not None
+    assert ds.duo_codes[0].id == "DUO:0000007"
+
+    # duo_codes=None always passes
+    ds_dict["duo_codes"] = None
+    ds_dict["resources"] = None
+    DatasetModelBase.model_validate(ds_dict)  # no error


### PR DESCRIPTION
## Summary
- Add `duo_codes: list[OntologyClass] | None` to `DatasetModelBase` for Data Use Ontology (DUO) codes describing dataset access conditions
- CURIE-prefix resource validation added in `check_keyword_resources`, consistent with existing `keywords`/`taxa` pattern
- Test coverage for valid, missing-resource, and `None` cases